### PR TITLE
fix: catch errors properly in `wrap_call`

### DIFF
--- a/src/apm.ml
+++ b/src/apm.ml
@@ -115,7 +115,7 @@ let with_transaction ?trace ~name ~type_ f =
     send
       [
         Transaction (Transaction.finalize transaction);
-        Error (Error.make ~trace st exn);
+        Error (Error.make ~parent:(`Trace trace) st exn);
       ];
     raise exn
 
@@ -132,7 +132,7 @@ let with_transaction_lwt ?trace ~name ~type_ f =
     send
       [
         Transaction (Transaction.finalize transaction);
-        Error (Error.make ~trace st exn);
+        Error (Error.make ~parent:(`Trace trace) st exn);
       ];
     Lwt.fail exn
   in

--- a/src/span.ml
+++ b/src/span.ml
@@ -77,16 +77,3 @@ let make_span
       ~subtype ~action ~context ()
   in
   { finalize; id; trace_id }
-
-let wrap_call
-    ?(context = Context.empty)
-    ~name
-    ~type_
-    ~subtype
-    ~action
-    ~parent
-    (f : unit -> 'a) =
-  let span = make_span ~name ~type_ ~subtype ~action ~parent ~context () in
-  let v = f () in
-  let (_ : result) = finalize_and_send span in
-  v

--- a/src/util.ml
+++ b/src/util.ml
@@ -4,3 +4,23 @@ let read_file path =
   Lwt_unix.openfile path [ Unix.O_RDONLY ] 0o640
   >|= Lwt_io.of_fd ~mode:Lwt_io.Input
   >>= Lwt_io.read
+
+let wrap_call
+    ?(context = Span.Context.empty)
+    ~name
+    ~type_
+    ~subtype
+    ~action
+    ~parent
+    (f : unit -> 'a) =
+  let span = Span.make_span ~name ~type_ ~subtype ~action ~parent ~context () in
+  match f () with
+  | v ->
+    let (_ : Span.result) = Span.finalize_and_send span in
+    v
+  | exception exn ->
+    let st = Printexc.get_raw_backtrace () in
+    let error = Error.make ~parent:(parent :> Error.parent) st exn in
+    Message_queue.push (Error.to_message_yojson error);
+    let (_ : Span.result) = Span.finalize_and_send span in
+    raise exn


### PR DESCRIPTION
This moves `Span.wrap_call` to `Util.wrap_call` and properly catches & bubbles up exceptions in that function.