### PR TITLE
feat: add flag to disable inclusion of CLI flags in metadata

### DIFF
--- a/src/apm.ml
+++ b/src/apm.ml
@@ -7,8 +7,6 @@ module Sender = struct
 
   let global_sender : t option ref = ref None
 
-  let enable_system_metrics : bool ref = ref false
-
   let make_headers (context : Context.t) =
     let headers = [ ("content-type", "application/x-ndjson") ] in
     match context with
@@ -60,7 +58,7 @@ module Sender = struct
       | None -> sleep ()
       | Some { max_message_batch_size; context; send } ->
         let (send, max_message_batch_size) =
-          if !enable_system_metrics then
+          if !Conf.enable_system_metrics then
             ( (fun messages ->
                 let* system_metrics = Metric.system () in
                 match system_metrics with
@@ -96,10 +94,12 @@ let init
     ?(max_message_batch_size = 50)
     ?(send = Sender.send)
     ?(enable_system_metrics = false)
+    ?(include_cli_args = true)
     ?(log_level : Logs.level option)
     context =
   Sender.global_sender := Some { max_message_batch_size; context; send };
-  Sender.enable_system_metrics := enable_system_metrics;
+  Conf.enable_system_metrics := enable_system_metrics;
+  Conf.include_cli_args := include_cli_args;
   Log.set_level log_level;
   Lwt.async Sender.run_forever
 

--- a/src/conf.ml
+++ b/src/conf.ml
@@ -1,0 +1,3 @@
+let enable_system_metrics = ref false
+
+let include_cli_args = ref true

--- a/src/metadata.ml
+++ b/src/metadata.ml
@@ -6,8 +6,10 @@ type process = {
 }
 [@@deriving to_yojson, make]
 
-let current_process =
-  let argv = Sys.argv |> Array.to_list in
+let current_process () =
+  let argv = match !Conf.include_cli_args with
+  | true -> Sys.argv |> Array.to_list 
+  | false -> [] in
   let title = Sys.executable_name in
   let pid = Unix.getpid () in
   let ppid = Unix.getppid () in
@@ -72,4 +74,4 @@ let to_message_yojson t = `Assoc [ ("metadata", to_yojson t) ]
 
 let make ~name =
   let service = make_service name in
-  make ~process:current_process ~system:current_system ~service
+  make ~process:(current_process ()) ~system:current_system ~service


### PR DESCRIPTION
This is mostly for security purposes -- there are often times where there are things like secret keys that are passed in as CLI flags. This adds an optional parameter to `init` (`include_cli_args`) that determines if they are sent back to the APM server.