### PR TITLE
fix: more safety around dropped messages

### DIFF
--- a/src/apm.ml
+++ b/src/apm.ml
@@ -48,14 +48,17 @@ module Sender = struct
             body
       )
 
-  let sleep () = Lwt_unix.sleep 5.0
+  let dynamic_sleep () =
+    let queue_size = Message_queue.size () in
+    let roomf = float (!Conf.max_queue_size - queue_size) in
+    Lwt_unix.sleep (!Conf.ratio_of_max_wait_time_to_max_queue_size *. roomf)
 
   let rec run_forever () =
     let ( let* ) = Lwt.bind in
     let open Lwt in
     let* () =
       match !global_sender with
-      | None -> sleep ()
+      | None -> Lwt_unix.sleep 5.0
       | Some { max_message_batch_size; context; send } ->
         let (send, max_message_batch_size) =
           if !Conf.enable_system_metrics then
@@ -85,13 +88,15 @@ module Sender = struct
           in
           send messages
         )
-        >>= sleep
+        >>= dynamic_sleep
     in
     run_forever ()
 end
 
 let init
-    ?(max_message_batch_size = 50)
+    ?(max_message_batch_size = Conf.Defaults.max_message_batch_size)
+    ?(max_queue_size = Conf.Defaults.max_queue_size)
+    ?(max_wait_time = Conf.Defaults.max_wait_time)
     ?(send = Sender.send)
     ?(enable_system_metrics = false)
     ?(include_cli_args = true)
@@ -100,6 +105,10 @@ let init
   Sender.global_sender := Some { max_message_batch_size; context; send };
   Conf.enable_system_metrics := enable_system_metrics;
   Conf.include_cli_args := include_cli_args;
+  Conf.max_queue_size := max_queue_size;
+  Conf.max_wait_time := max_wait_time;
+  Conf.ratio_of_max_wait_time_to_max_queue_size :=
+    max_wait_time /. float max_queue_size;
   Log.set_level log_level;
   Lwt.async Sender.run_forever
 

--- a/src/apm.ml
+++ b/src/apm.ml
@@ -59,7 +59,7 @@ module Sender = struct
     let open Lwt in
     let* () =
       match !global_sender with
-      | None -> Lwt_unix.sleep 5.0
+      | None -> Lwt_unix.sleep !Conf.max_wait_time
       | Some { max_message_batch_size; context; send } ->
         let (send, max_message_batch_size) =
           if !Conf.enable_system_metrics then

--- a/src/apm.ml
+++ b/src/apm.ml
@@ -51,7 +51,8 @@ module Sender = struct
   let dynamic_sleep () =
     let queue_size = Message_queue.size () in
     let roomf = float (!Conf.max_queue_size - queue_size) in
-    Lwt_unix.sleep (!Conf.ratio_of_max_wait_time_to_max_queue_size *. roomf)
+    Lwt_unix.sleep
+      ((!Conf.sleep_ratio *. roomf) +. (0.1 *. float !Conf.max_queue_size))
 
   let rec run_forever () =
     let ( let* ) = Lwt.bind in
@@ -107,8 +108,7 @@ let init
   Conf.include_cli_args := include_cli_args;
   Conf.max_queue_size := max_queue_size;
   Conf.max_wait_time := max_wait_time;
-  Conf.ratio_of_max_wait_time_to_max_queue_size :=
-    max_wait_time /. float max_queue_size;
+  Conf.sleep_ratio := 0.9 *. max_wait_time /. float max_queue_size;
   Log.set_level log_level;
   Lwt.async Sender.run_forever
 

--- a/src/conf.ml
+++ b/src/conf.ml
@@ -1,3 +1,13 @@
-let enable_system_metrics = ref false
-
-let include_cli_args = ref true
+module Defaults = struct
+  let enable_system_metrics = false
+  let include_cli_args = true
+  let max_queue_size = 10000
+  let max_message_batch_size = 100
+  let max_wait_time = 5.0
+end
+let enable_system_metrics = ref Defaults.enable_system_metrics
+let include_cli_args = ref Defaults.include_cli_args
+let max_queue_size = ref Defaults.max_queue_size
+let max_wait_time = ref Defaults.max_wait_time
+let ratio_of_max_wait_time_to_max_queue_size =
+  ref (Defaults.max_wait_time /. float Defaults.max_queue_size)

--- a/src/conf.ml
+++ b/src/conf.ml
@@ -9,5 +9,5 @@ let enable_system_metrics = ref Defaults.enable_system_metrics
 let include_cli_args = ref Defaults.include_cli_args
 let max_queue_size = ref Defaults.max_queue_size
 let max_wait_time = ref Defaults.max_wait_time
-let ratio_of_max_wait_time_to_max_queue_size =
-  ref (Defaults.max_wait_time /. float Defaults.max_queue_size)
+let sleep_ratio =
+  ref (0.9 *. Defaults.max_wait_time /. float Defaults.max_queue_size)

--- a/src/message_queue.ml
+++ b/src/message_queue.ml
@@ -1,9 +1,9 @@
 let q : Yojson.Safe.t Queue.t = Queue.create ()
-let max_length = ref 1000
+let max_length = 1000
 
 let rec make_room () =
   let length = Queue.length q in
-  if length > 0 && length >= !max_length then (
+  if length > 0 && length >= max_length then (
     let _discarded = Queue.take q in
     make_room ()
   )

--- a/src/message_queue.ml
+++ b/src/message_queue.ml
@@ -1,10 +1,15 @@
 let q : Yojson.Safe.t Queue.t = Queue.create ()
-let max_length = 1000
+
+let size () = Queue.length q
 
 let rec make_room () =
   let length = Queue.length q in
-  if length > 0 && length >= max_length then (
-    let _discarded = Queue.take q in
+  if length > 0 && length >= !Conf.max_queue_size then (
+    let discarded = Queue.take q in
+    Logs.warn (fun m ->
+        m "Dropping APM message due to queue exceeding max size: %a"
+          Yojson.Safe.pp discarded
+    );
     make_room ()
   )
 


### PR DESCRIPTION
Messages can be dropped for a couple reasons:
1. The queue is too big and we need to discard messages
2. The batch message size is too small, leading to 1
3. The sleep time is too long, leading to 1

This fixes the above three by:
- Increasing maximum queue size
- Increasing batch size
- Implementing dynamic sleep
  - We always sleep at least 10% of the maximum sleep time, the other 90% is determined by the amount of room left in the queue.