### PR TITLE
refactor(metric): add `Metric.send`

### DIFF
--- a/example/cohttp_server_example.ml
+++ b/example/cohttp_server_example.ml
@@ -83,5 +83,5 @@ let () =
       ~timestamp:(Skapm.Timestamp.now_ms ())
       ()
   in
-  Skapm.Apm.send [ Metric custom_metric ];
+  Skapm.Metric.send custom_metric;
   Lwt_main.run server |> ignore

--- a/src/metric.ml
+++ b/src/metric.ml
@@ -30,6 +30,8 @@ type t = {
 
 let to_message_yojson t = `Assoc [ ("metricset", to_yojson t) ]
 
+let send t = Message_queue.push (to_message_yojson t)
+
 let prev_idle_time = ref None
 let prev_total_time = ref None
 


### PR DESCRIPTION
This allows you to send metrics through the `Metric` module rather than `Skapm.Apm.send`.