### PR TITLE
refactor(error): add `Error.send`

### DIFF
--- a/src/error.ml
+++ b/src/error.ml
@@ -55,6 +55,8 @@ type parent =
 
 let to_message_yojson t = `Assoc [ ("error", to_yojson t) ]
 
+let send t = Message_queue.push (to_message_yojson t)
+
 let make ?(parent : parent option) st (exn : exn) : t =
   let id = Id.make () in
   let timestamp = Timestamp.now_ms () in


### PR DESCRIPTION
This takes care of the last type of APM message that can be sent. My bad for not including this in #12 