### PR TITLE
refactor(error): rename `make` to `of_exn`

### DIFF
--- a/src/apm.ml
+++ b/src/apm.ml
@@ -133,7 +133,7 @@ let with_transaction ?trace ~name ~type_ f =
     send
       [
         Transaction (Transaction.finalize transaction);
-        Error (Error.make ~parent:(`Trace trace) st exn);
+        Error (Error.of_exn ~parent:(`Trace trace) st exn);
       ];
     raise exn
 
@@ -150,7 +150,7 @@ let with_transaction_lwt ?trace ~name ~type_ f =
     send
       [
         Transaction (Transaction.finalize transaction);
-        Error (Error.make ~parent:(`Trace trace) st exn);
+        Error (Error.of_exn ~parent:(`Trace trace) st exn);
       ];
     Lwt.fail exn
   in

--- a/src/error.ml
+++ b/src/error.ml
@@ -57,7 +57,7 @@ let to_message_yojson t = `Assoc [ ("error", to_yojson t) ]
 
 let send t = Message_queue.push (to_message_yojson t)
 
-let make ?(parent : parent option) st (exn : exn) : t =
+let of_exn ?(parent : parent option) st (exn : exn) : t =
   let id = Id.make () in
   let timestamp = Timestamp.now_ms () in
   let (parent_id, trace_id) =

--- a/src/error.ml
+++ b/src/error.ml
@@ -32,7 +32,7 @@ module Exception = struct
   }
   [@@deriving to_yojson, make]
 
-  let make st (exn : exn) : t =
+  let of_exn st (exn : exn) : t =
     let stacktrace = Stack_trace.make_stacktrace st in
     make ~message:(Printexc.to_string exn) ~type_:"exn" ~stacktrace
 end
@@ -68,5 +68,5 @@ let of_exn ?(parent : parent option) st (exn : exn) : t =
     | Some (`Trace trace) -> (None, Some trace.trace_id)
     | None -> (None, None)
   in
-  let exception_ = Exception.make st exn in
+  let exception_ = Exception.of_exn st exn in
   make ~id ~timestamp ?trace_id ?parent_id ~exception_ ()

--- a/src/util.ml
+++ b/src/util.ml
@@ -20,7 +20,7 @@ let wrap_call
     v
   | exception exn ->
     let st = Printexc.get_raw_backtrace () in
-    let error = Error.make ~parent:(parent :> Error.parent) st exn in
+    let error = Error.of_exn ~parent:(parent :> Error.parent) st exn in
     Message_queue.push (Error.to_message_yojson error);
     let (_ : Span.result) = Span.finalize_and_send span in
     raise exn


### PR DESCRIPTION
This was shadowing the actual `make`, which we avoid in other modules by naming the function `make_{module}`. However, here I think it makes more sense to explicitly state that this function constructs `Error.t`s from `exn`s.