### PR TITLE
feat(error): add `of_result`

### DIFF
--- a/src/error.ml
+++ b/src/error.ml
@@ -67,8 +67,8 @@ let parent_ids (parent : parent option) =
 
 let of_result
     ?(parent : parent option)
-    (res : (_, 'err) result)
-    (pp : 'err Fmt.t) =
+    ~(pp : 'err Fmt.t)
+    (res : (_, 'err) result) =
   match res with
   | Error e ->
     let id = Id.make () in

--- a/src/error.ml
+++ b/src/error.ml
@@ -76,7 +76,7 @@ let of_result
     let (parent_id, trace_id) = parent_ids parent in
     let msg = Fmt.str "%a" pp e in
     let exception_ =
-      Exception.{ message = msg; type_ = "result"; stacktrace = [] }
+      Exception.make ~message:msg ~type_:"result" ~stacktrace:[]
     in
     Some (make ~id ~timestamp ?trace_id ?parent_id ~exception_ ())
   | Ok _ -> None

--- a/src/error.ml
+++ b/src/error.ml
@@ -57,16 +57,33 @@ let to_message_yojson t = `Assoc [ ("error", to_yojson t) ]
 
 let send t = Message_queue.push (to_message_yojson t)
 
+let parent_ids (parent : parent option) =
+  match parent with
+  | Some (`Span span) -> (Some span.id, Some span.trace_id)
+  | Some (`Transaction transaction) ->
+    (Some transaction.id, Some transaction.trace_id)
+  | Some (`Trace trace) -> (None, Some trace.trace_id)
+  | None -> (None, None)
+
+let of_result
+    ?(parent : parent option)
+    (res : (_, 'err) result)
+    (pp : 'err Fmt.t) =
+  match res with
+  | Error e ->
+    let id = Id.make () in
+    let timestamp = Timestamp.now_ms () in
+    let (parent_id, trace_id) = parent_ids parent in
+    let msg = Fmt.str "%a" pp e in
+    let exception_ =
+      Exception.{ message = msg; type_ = "result"; stacktrace = [] }
+    in
+    Some (make ~id ~timestamp ?trace_id ?parent_id ~exception_ ())
+  | Ok _ -> None
+
 let of_exn ?(parent : parent option) st (exn : exn) : t =
   let id = Id.make () in
   let timestamp = Timestamp.now_ms () in
-  let (parent_id, trace_id) =
-    match parent with
-    | Some (`Span span) -> (Some span.id, Some span.trace_id)
-    | Some (`Transaction transaction) ->
-      (Some transaction.id, Some transaction.trace_id)
-    | Some (`Trace trace) -> (None, Some trace.trace_id)
-    | None -> (None, None)
-  in
+  let (parent_id, trace_id) = parent_ids parent in
   let exception_ = Exception.of_exn st exn in
   make ~id ~timestamp ?trace_id ?parent_id ~exception_ ()


### PR DESCRIPTION
This allows us to construct errors from results rather than just `exn`s.