### PR TITLE
fix(logs): rename `Log` module, fix scoping

### DIFF
--- a/src/apm.ml
+++ b/src/apm.ml
@@ -1,3 +1,5 @@
+open Logger
+
 module Sender = struct
   type t = {
     max_message_batch_size : int;
@@ -42,7 +44,7 @@ module Sender = struct
     match response.status with
     | #Cohttp.Code.success_status -> Lwt.return_unit
     | _ ->
-        Log.warn (fun m ->
+        Log_lwt.warn (fun m ->
             m "APM server response %d: %s"
               (Cohttp.Code.code_of_status response.status)
               body)
@@ -79,7 +81,7 @@ module Sender = struct
           | [] -> Lwt.return_unit
           | _ ->
               let* () =
-                Logs_lwt.debug (fun m ->
+                Log_lwt.debug (fun m ->
                     m "Sending messages: %a"
                       (Fmt.list Yojson.Safe.pretty_print)
                       messages)
@@ -101,7 +103,7 @@ let init ?(max_message_batch_size = Conf.Defaults.max_message_batch_size)
   Conf.max_queue_size := max_queue_size;
   Conf.max_wait_time := max_wait_time;
   Conf.sleep_ratio := 0.9 *. max_wait_time /. float max_queue_size;
-  Log.set_level log_level;
+  Logger.set_level log_level;
   Lwt.async Sender.run_forever
 
 let send messages =

--- a/src/logger.ml
+++ b/src/logger.ml
@@ -1,7 +1,5 @@
 let log_src = Logs.Src.create "apm"
-
-module Log = (val Logs_lwt.src_log log_src)
-
 let set_level level = Logs.Src.set_level log_src level
 
-include Log
+module Log = (val Logs.src_log log_src)
+module Log_lwt = (val Logs_lwt.src_log log_src)

--- a/src/message_queue.ml
+++ b/src/message_queue.ml
@@ -1,3 +1,5 @@
+open Logger
+
 let q : Yojson.Safe.t Queue.t = Queue.create ()
 let size () = Queue.length q
 
@@ -7,7 +9,7 @@ let rec make_room num_dropped =
     let (_ : Yojson.Safe.t) = Queue.take q in
     make_room (num_dropped + 1)
   else if num_dropped > 0 then
-    Logs.warn (fun m ->
+    Log.warn (fun m ->
         m "Forced to drop %d message(s) to make room in queue" num_dropped)
 
 let push message =


### PR DESCRIPTION
Because we weren't properly scoping our logs here, they would bleed into the application source in executables. This makes it so that all logs emitted from Skapm are scoped.