### PR TITLE
feat(metrics): add process level metrics

### DIFF
--- a/example/dune
+++ b/example/dune
@@ -1,3 +1,9 @@
 (executables
  (names cohttp_server_example)
+ (modules cohttp_server_example)
  (libraries skapm cohttp-lwt-unix))
+
+(executables
+ (names gc_metrics)
+ (modules gc_metrics)
+ (libraries skapm))

--- a/example/gc_metrics.ml
+++ b/example/gc_metrics.ml
@@ -1,0 +1,32 @@
+open Lwt.Infix
+
+let allocate ~wait n () =
+  (* allocate an array of size [n] *)
+  Lwt_io.printf "allocating an array of size %d\n" n >>= fun () ->
+  let arr = Array.make n () in
+  Lwt_io.printf "sleeping for %fs\n" wait >>= fun () ->
+  (* sleep for [wait] *)
+  Lwt_unix.sleep wait
+  >|= (fun () ->
+        (* ensure the GC doesn't prematurely collect the array *)
+        let (_ : unit array) = Sys.opaque_identity arr in
+        ())
+  >|= Gc.full_major (* force a major heap collection *)
+
+let () =
+  let log_src = Logs.Src.create "apm" in
+  Logs.Src.set_level log_src (Some Logs.Debug);
+  let service_name = "gc_metrics" in
+  let secret_token = Sys.getenv "APM_SECRET_TOKEN" in
+  let url = Sys.getenv "APM_URL" |> Uri.of_string in
+  let context =
+    Skapm.Context.make ~secret_token ~service_name ~apm_server:url ()
+  in
+  Logs.set_reporter @@ Logs_fmt.reporter ();
+  Skapm.Apm.init ~enable_process_metrics:true context;
+  let rec f = (fun () ->
+    let n = Random.int 10_000 in
+    let wait = (Random.int 50 |> Float.of_int) /. 5. in
+    allocate ~wait n () >>= f
+  ) in
+  Lwt_main.run @@ f ()

--- a/src/apm.ml
+++ b/src/apm.ml
@@ -95,10 +95,11 @@ end
 let init ?(max_message_batch_size = Conf.Defaults.max_message_batch_size)
     ?(max_queue_size = Conf.Defaults.max_queue_size)
     ?(max_wait_time = Conf.Defaults.max_wait_time) ?(send = Sender.send)
-    ?(enable_system_metrics = false) ?(include_cli_args = true)
-    ?(log_level : Logs.level option) context =
+    ?(enable_system_metrics = false) ?(enable_process_metrics = false)
+    ?(include_cli_args = true) ?(log_level : Logs.level option) context =
   Sender.global_sender := Some { max_message_batch_size; context; send };
   Conf.enable_system_metrics := enable_system_metrics;
+  Conf.enable_process_metrics := enable_process_metrics;
   Conf.include_cli_args := include_cli_args;
   Conf.max_queue_size := max_queue_size;
   Conf.max_wait_time := max_wait_time;

--- a/src/conf.ml
+++ b/src/conf.ml
@@ -1,4 +1,5 @@
 module Defaults = struct
+  let enable_process_metrics = false
   let enable_system_metrics = false
   let include_cli_args = true
   let max_queue_size = 10000
@@ -7,6 +8,7 @@ module Defaults = struct
 end
 
 let enable_system_metrics = ref Defaults.enable_system_metrics
+let enable_process_metrics = ref Defaults.enable_process_metrics
 let include_cli_args = ref Defaults.include_cli_args
 let max_queue_size = ref Defaults.max_queue_size
 let max_wait_time = ref Defaults.max_wait_time

--- a/src/util.ml
+++ b/src/util.ml
@@ -1,10 +1,16 @@
+let ( let+ ) = Lwt.bind
+
 let read_file path =
-  let ( let+ ) = Lwt.bind in
   let+ fd = Lwt_unix.openfile path [ Unix.O_RDONLY ] 0o640 in
   let io = Lwt_io.of_fd ~mode:Lwt_io.Input fd in
   let+ str = Lwt_io.read io in
   let+ () = Lwt_unix.close fd in
   Lwt.return str
+
+let run_cmd cmd =
+  let cmd = Lwt_process.shell cmd in
+  let output = Lwt_process.open_process_in cmd in
+  Lwt_io.read output#stdout
 
 let wrap_call ?(context = Span.Context.empty) ~name ~type_ ~subtype ~action
     ~parent (f : unit -> 'a) =

--- a/src/util.ml
+++ b/src/util.ml
@@ -9,7 +9,7 @@ let read_file path =
 
 let run_cmd cmd =
   let cmd = Lwt_process.shell cmd in
-  let output = Lwt_process.open_process_in cmd in
+  let output = Lwt_process.open_process_in ~stderr:`Dev_null cmd in
   Lwt_io.read output#stdout
 
 let wrap_call ?(context = Span.Context.empty) ~name ~type_ ~subtype ~action
@@ -25,3 +25,6 @@ let wrap_call ?(context = Span.Context.empty) ~name ~type_ ~subtype ~action
       Error.send error;
       let (_ : Span.result) = Span.finalize_and_send span in
       raise exn
+
+let cons_opt opt l = match opt with Some x -> x :: l | None -> l
+let ( +? ) = cons_opt


### PR DESCRIPTION
This collects the stats provided by `Gc.quick_stat`, as well as the number of open file descriptors.