### PR TITLE
feat: add more info to transaction and span contexts

### DIFF
--- a/src/http.ml
+++ b/src/http.ml
@@ -1,30 +1,4 @@
-type headers = (string * string) list
-
-let headers_to_yojson (headers : headers) =
-  (`Assoc (List.map (fun (k, v) -> (k, `String v)) headers) :> Yojson.Safe.t)
-
-type response = {
-  status_code : int;
-  transfer_size : int option;
-  headers : headers option;
-}
-[@@deriving to_yojson, make]
-
-type url = {
-  protocol : string option;
-  full : string;
-  hostname : string option;
-  port : int option;
-  pathname : string;
-}
-[@@deriving to_yojson, make]
-
-type request = {
-  meth : string; [@key "method"]
-  url : url;
-  http_version : string;
-}
-[@@deriving to_yojson, make]
+include Types.Http
 
 let url_of_uri u =
   let protocol = Uri.scheme u in
@@ -33,15 +7,3 @@ let url_of_uri u =
   let port = Uri.port u in
   let pathname = Uri.path u in
   make_url ?protocol ~full ?hostname ?port ~pathname ()
-
-let make_request ~meth ~uri ~http_version =
-  let url = url_of_uri uri in
-  make_request ~meth ~url ~http_version
-
-let response_of_cohttp (resp : Cohttp.Response.t) =
-  let open Cohttp in
-  {
-    status_code = resp |> Response.status |> Code.code_of_status;
-    headers = Some (resp |> Response.headers |> Header.to_list);
-    transfer_size = None;
-  }

--- a/src/util.ml
+++ b/src/util.ml
@@ -12,12 +12,11 @@ let run_cmd cmd =
   let output = Lwt_process.open_process_in ~stderr:`Dev_null cmd in
   Lwt_io.read output#stdout
 
-let wrap_call ?(context = Span.Context.empty) ~name ~type_ ~subtype ~action
-    ~parent (f : unit -> 'a) =
-  let span = Span.make_span ~name ~type_ ~subtype ~action ~parent ~context () in
+let wrap_call ?context ~name ~type_ ~subtype ~action ~parent (f : unit -> 'a) =
+  let span = Span.make_span ~name ~type_ ~subtype ~action ~parent () in
   match f () with
   | v ->
-      let (_ : Span.result) = Span.finalize_and_send span in
+      let (_ : Span.result) = Span.finalize_and_send ?context span in
       v
   | exception exn ->
       let st = Printexc.get_raw_backtrace () in


### PR DESCRIPTION
This adds more info (specifically HTTP metadata) to both the transaction and span contexts, and changes the API such that contexts are passed into the finalizer.

This is obviously a breaking API change, so I'm going to have to go through skmysql and skrest (and possibly sklogs? not sure) to update them. I'll add better version constraints there as well.