### PR TITLE
fix(apm): cap APM server response logs to 256 characters

### DIFF
--- a/src/apm.ml
+++ b/src/apm.ml
@@ -52,9 +52,9 @@ module Sender = struct
         | #Cohttp.Code.success_status -> Lwt.return_unit
         | _ ->
             Log_lwt.warn (fun m ->
-                m "APM server response %d: %s"
+                m "APM server response %d: %a"
                   (Cohttp.Code.code_of_status response.status)
-                  body))
+                  (Util.pp_str_ellipsize ()) body))
       (fun exn ->
         Log_lwt.warn (fun f -> f "Error sending APM data: %a" Fmt.exn exn))
 

--- a/src/util.ml
+++ b/src/util.ml
@@ -27,3 +27,9 @@ let wrap_call ?context ~name ~type_ ~subtype ~action ~parent (f : unit -> 'a) =
 
 let cons_opt opt l = match opt with Some x -> x :: l | None -> l
 let ( +? ) = cons_opt
+
+let pp_str_ellipsize ?(max_len = 256) () fmt str =
+  if String.length str > max_len then (
+    Format.pp_print_string fmt (String.sub str 0 (max_len - 1));
+    Format.pp_print_string fmt "\u{2026}")
+  else Format.pp_print_string fmt str


### PR DESCRIPTION
This was presenting a bunch of issues with large APM traces that were being rejected (i.e. with very long SQL queries).