### PR TITLE
fix(util): don't leak fds when forking

### DIFF
--- a/src/metric.ml
+++ b/src/metric.ml
@@ -51,8 +51,11 @@ let get_free_memory file =
   |> Lwt_result.catch
 
 let get_open_fds () =
-  Util.run_cmd "ls -a /proc/self/fd/ | wc -l"
-  >|= int_of_string |> Lwt_result.catch
+  Lwt_result.Infix.(
+    Util.run_cmd "ls -a /proc/self/fd/ | wc -l"
+    |> Lwt_result.catch >|= String.trim
+    >>= fun i ->
+    try Lwt.return_ok (int_of_string i) with exn -> Lwt.return_error exn)
 
 let process () =
   let timestamp = Timestamp.now_ms () in

--- a/src/util.ml
+++ b/src/util.ml
@@ -10,7 +10,9 @@ let read_file path =
 let run_cmd cmd =
   let cmd = Lwt_process.shell cmd in
   let output = Lwt_process.open_process_in ~stderr:`Dev_null cmd in
-  Lwt_io.read output#stdout
+  let stdout = Lwt_io.read output#stdout in
+  let+ (_ : Unix.process_status) = output#close in
+  stdout
 
 let wrap_call ?context ~name ~type_ ~subtype ~action ~parent (f : unit -> 'a) =
   let span = Span.make_span ~name ~type_ ~subtype ~action ~parent () in


### PR DESCRIPTION
This also adds a small fix to the open FDs metric by trimming whitespace from the string.